### PR TITLE
Fix an error that happens without this

### DIFF
--- a/src/Pornsearch.js
+++ b/src/Pornsearch.js
@@ -76,7 +76,7 @@ class Pornsearch {
   }
 
   load () {
-    let dir = Path.resolve('./src/Modules');
+    let dir = Path.join(__dirname, 'Modules');
     let files = FS.readdirSync(dir, 'UTF-8');
 
     this.modules = files.map(file => AbstractModule.extendsToMe(new (require(Path.resolve(dir, file)))));


### PR DESCRIPTION
When using Path.resolve(`./src/Modules`) it will return `Error: ENOENT: no such file or directory, scandir`, or in other words, it won't be able to find the directory. This at least counts for Windows systems however `path.join` is a method that works regardless of the system and generally highly recommended whatsoever. More on [path.join here](https://nodejs.org/api/path.html#path_path_join_paths). and on the [__dirname variable here](https://nodejs.org/docs/latest/api/modules.html#modules_dirname)